### PR TITLE
RDKCOM-5356: OneWifi and WFO features should not force platform to us…

### DIFF
--- a/source/bridge_utils/bridge_utils_bin/bridge_util.c
+++ b/source/bridge_utils/bridge_utils_bin/bridge_util.c
@@ -2826,11 +2826,10 @@ void getSettings()
         	bridge_util_log("syscfg_get failed to retrieve ovs_enable\n");
 
         }
-        if( (0 == access( ONEWIFI_ENABLED, F_OK )) || (0 == access( OPENVSWITCH_LOADED, F_OK ))
-                                                   || (access(WFO_ENABLED, F_OK) == 0 ) )
+        if( 0 == access( OPENVSWITCH_LOADED, F_OK ) )
         {
             ovsEnable = 1;
-            bridge_util_log("setting ovsEnable to true for onewifi/WFO build\n");
+            bridge_util_log("setting ovsEnable to true for OVS build\n");
         }
 
         memset(buf,0,sizeof(buf));


### PR DESCRIPTION
…e OVS

Reason for change: Usage of OneWifi and WFO features forces platform
 to use OVS
Test Procedure: Check the build
Risks: None
Signed-off-by: Danil Chestyunin <dchestyunin@maxlinear.com>
Priority: P1

Change-Id: I3af7094af659ab3852f6b6a450905b6e8836f047 (cherry picked from commit 087369dceb7240fbc48221c1f6bd5bb200563a65)