### PR TITLE
Revert "RDKCOM-5356 to fix CBR2-2206: OneWifi and WFO features should not force platform to use OVS"

### DIFF
--- a/source/bridge_utils/bridge_utils_bin/bridge_util.c
+++ b/source/bridge_utils/bridge_utils_bin/bridge_util.c
@@ -2860,10 +2860,11 @@ void getSettings()
         	bridge_util_log("syscfg_get failed to retrieve ovs_enable\n");
 
         }
-        if( 0 == access( OPENVSWITCH_LOADED, F_OK ) )
+        if( (0 == access( ONEWIFI_ENABLED, F_OK )) || (0 == access( OPENVSWITCH_LOADED, F_OK ))
+                                                   || (access(WFO_ENABLED, F_OK) == 0 ) )
         {
             ovsEnable = 1;
-            bridge_util_log("setting ovsEnable to true for OVS build\n");
+            bridge_util_log("setting ovsEnable to true for onewifi/WFO build\n");
         }
 
         memset(buf,0,sizeof(buf));


### PR DESCRIPTION
Reason for revert: To see if revert fixes CBR2-2206

This reverts commit 7973b57a9966fb2837c2d3c29dcda6c32d0a952b.

Change-Id: Ie9c72311c26684f1712e56f40f1ea64f3d5236f4