### PR TITLE
XER10-2116: DML X_RDKCENTRAL-COM_InActiveFirmwarenot supported in XER10

### DIFF
--- a/source/FwBankInfo/FwBank_Info.c
+++ b/source/FwBankInfo/FwBank_Info.c
@@ -16,7 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
 */
-#if !defined(_SR213_PRODUCT_REQ_) && !defined (_WNXL11BWL_PRODUCT_REQ_) && !defined (_SCER11BEL_PRODUCT_REQ_)
+#if !defined(_SR213_PRODUCT_REQ_) && !defined (_WNXL11BWL_PRODUCT_REQ_)
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -40,7 +40,7 @@ FILE* logFp = NULL;
 
 int main()
 {
-#if !defined(_SR213_PRODUCT_REQ_) && !defined (_WNXL11BWL_PRODUCT_REQ_) && !defined (_SCER11BEL_PRODUCT_REQ_)
+#if !defined(_SR213_PRODUCT_REQ_) && !defined (_WNXL11BWL_PRODUCT_REQ_) 
     int ret;
     int rc = -1;
     PFW_BANK_INFO pfw_bank=NULL;


### PR DESCRIPTION
Reason for change:
The DML Device.DeviceInfo.X_RDKCENTRAL-COM_InActiveFirmware returns empty value. This dml is used for operational purposes to know about firmware in-active banks.

Test Procedure:
Check Device.DeviceInfo.X_RDKCENTRAL-COM_InActiveFirmware Risks: Low
Priority: P1
Signed-off-by: Robert_Lee2@comcast.com

Change-Id: I99e452d5780584a03f828b6b3544c60e383fb600 (cherry picked from commit 0bc8bda87d26469aae2fed000e2356d488fdc14a)