### PR TITLE
RDKB-62013: DUT moves to ethwan mode in RF disconnect state.

### DIFF
--- a/source/bridge_utils/scripts/migration_to_psm.sh
+++ b/source/bridge_utils/scripts/migration_to_psm.sh
@@ -81,6 +81,13 @@ if [ "xcompleted" != "x`syscfg get psm_migration`" ];then
 		psmcli set dmsb.l2net.2.Port.2.Name "eth1"
 		psmcli set dmsb.l2net.2.Port.2.LinkName "eth1"
 		psmcli get dmsb.l2net.2.Members.SW ""
+ 
+		if [ "$MODEL_NUM" == "CGM601TCOM" ] ||  [ "$MODEL_NUM" == "SG417DBCT" ];then
+                    if [ ! -f "/nvram/.psm_disable_ethwan_selection" ];then
+                        psmcli set dmsb.wanmanager.if.2.Selection.Enable "FALSE"
+                        touch /nvram/.psm_disable_ethwan_selection
+                    fi
+                fi
 		
 		migrationCompleteFlag=1
 	fi

--- a/source/bridge_utils/scripts/migration_to_psm.sh
+++ b/source/bridge_utils/scripts/migration_to_psm.sh
@@ -83,17 +83,17 @@ if [ "xcompleted" != "x`syscfg get psm_migration`" ];then
 		psmcli get dmsb.l2net.2.Members.SW ""
  
 		if [ "$MODEL_NUM" == "CGM601TCOM" ] ||  [ "$MODEL_NUM" == "SG417DBCT" ];then
-                    if [ ! -f "/nvram/.psm_disable_ethwan_selection" ];then
-                        psmcli set dmsb.wanmanager.if.2.Selection.Enable "FALSE"
-                        touch /nvram/.psm_disable_ethwan_selection
-                    fi
-                fi
+            if [ ! -f "/nvram/.psm_disable_ethwan_selection" ];then
+                psmcli set dmsb.wanmanager.if.2.Selection.Enable "FALSE"
+                touch /nvram/.psm_disable_ethwan_selection
+            fi
+        fi
 		
 		migrationCompleteFlag=1
 	fi
 	if [ "$MODEL_NUM" = "TG3482G" ];then
 		for i in 1 2 3 4 5 6 7 8 9
-		do
+ 		do
 			psmcli set dmsb.l2net."$i".Members.Link ""
 			greIf=`psmcli get dmsb.l2net."$i".Members.Gre`
 			if [ x"$greIf" != "x" ];then


### PR DESCRIPTION
RDKB-62013: DUT moves to ethwan mode in RF disconnect state.
Reason for change: Migration fix to update psm to set Ethwan Interface selection to FALSE.
Test Procedure: Verify dmsb.wanmanager.if.2.Selection.Enable is set to FALSE in psm database.
Risks: None
Priority: P1
Signed-off-by: Jayant_Rai2@comcast.com