### PR TITLE
XB10-2690: Update psm to disable Ethwan interface selection.

### DIFF
--- a/source/bridge_utils/scripts/migration_to_psm.sh
+++ b/source/bridge_utils/scripts/migration_to_psm.sh
@@ -79,11 +79,11 @@ if [ "xcompleted" != "x`syscfg get psm_migration`" ];then
 			psmcli set dmsb.l2net.2.Members.Eth ""
 		fi 
 
-                if [ "$MODEL_NUM" == "CGM601TCOM" ] ||  [ "$MODEL_NUM" == "SG417DBCT" ];then
-                    if [ ! -f "/nvram/.xb10_enable_ethwan_mode" ];then
-                        psmcli set dmsb.wanmanager.if.2.Selection.Enable "FALSE"
-                    fi
-                fi
+		if [ "$MODEL_NUM" = "CGM601TCOM" ] || [ "$MODEL_NUM" = "SG417DBCT" ]; then
+			if [ ! -f "/nvram/.xb10_enable_ethwan_mode" ]; then
+				psmcli set dmsb.wanmanager.if.2.Selection.Enable "FALSE"
+			fi
+		fi
 
 		psmcli set dmsb.l2net.1.Port.9.LinkName ""
 		psmcli set dmsb.l2net.1.Port.9.Name ""

--- a/source/bridge_utils/scripts/migration_to_psm.sh
+++ b/source/bridge_utils/scripts/migration_to_psm.sh
@@ -78,6 +78,13 @@ if [ "xcompleted" != "x`syscfg get psm_migration`" ];then
 			fi
 			psmcli set dmsb.l2net.2.Members.Eth ""
 		fi 
+
+                if [ "$MODEL_NUM" == "CGM601TCOM" ] ||  [ "$MODEL_NUM" == "SG417DBCT" ];then
+                    if [ ! -f "/nvram/.xb10_enable_ethwan_mode" ];then
+                        psmcli set dmsb.wanmanager.if.2.Selection.Enable "FALSE"
+                    fi
+                fi
+
 		psmcli set dmsb.l2net.1.Port.9.LinkName ""
 		psmcli set dmsb.l2net.1.Port.9.Name ""
 		psmcli set dmsb.l2net.1.Port.8.LinkName "eth1"


### PR DESCRIPTION
Reason for change: Update psm to set Ethwan Interface selection to FALSE if override file '/nvram/.xb10_enable_ethwan_mode' is not present.
Test Procedure: Build & verify.
Risks: None
Priority: P1
Signed-off-by: Jayant_Rai2@comcast.com